### PR TITLE
Reduce Docker image size from 252MB to 122MB

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,11 @@
-FROM phusion/baseimage:noble
+FROM ubuntu:24.04
 
-RUN apt-get update && apt-get install -y \
+RUN apt-get update && apt-get install -y --no-install-recommends \
 python3-avahi \
 && rm -rf /var/lib/apt/lists/*
 
 COPY ./avahi-alias.py /usr/local/bin/avahi-alias
-RUN chmod +x /usr/local/bin/avahi-alias
 
 ENTRYPOINT []
 
-CMD bash -c "/usr/local/bin/avahi-alias ${BALENA_DEVICE_NAME_AT_INIT}.local ${CNAMES}"
+CMD ["bash", "-c", "/usr/local/bin/avahi-alias ${BALENA_DEVICE_NAME_AT_INIT}.local ${CNAMES}"]


### PR DESCRIPTION
- We're not using the init from phusion, so let's move to the latest Ubuntu LTS
- `--no-install-recommends` to save some size
- chmod is not needed because the file already has +x
- Remove Docker warning