### PR TITLE
Revert "Add option to run bumpver with a workflow"

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -2,12 +2,6 @@ name: CI
 
 on:
   workflow_dispatch:
-    inputs:
-      bumpver:
-        description: 'Run bumpver before building'
-        required: false
-        default: false
-        type: boolean
   push:
     branches:
       - 'main'
@@ -23,14 +17,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v6
-
-      - name: Run bumpver
-        if: ${{ github.ref == 'refs/heads/main' && github.event_name == 'workflow_dispatch' && inputs.bumpver }}
-        run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-          pip install bumpver
-          bumpver update --no-fetch
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3


### PR DESCRIPTION
The normal github action doesn't have permissions to run the "tag" workflow that follows after you push a tag. You can solve this by creating an App and get a token that way. But for this repo, let's keep it simple and manually run bumpver + push.

This reverts commit df3d63e4a2010639aea4066b585c13b615f11cf5. This reverts commit e7b8e8f008a71e5ae1a1f9d8e939b006e5753424.